### PR TITLE
Fix long order properties by rebalancing mudder strings

### DIFF
--- a/components/todos/create/useCreateTodoModal.ts
+++ b/components/todos/create/useCreateTodoModal.ts
@@ -1,9 +1,9 @@
 import { useIonModal } from '@ionic/react'
 import { HookOverlayOptions } from '@ionic/react/dist/types/hooks/HookOverlayOptions'
 import { useCallback, useRef } from 'react'
-import order from '../../common/order'
 import { db, ListType, Todo, TodoInput } from '../../db'
 import { useMarkdownExportContext } from '../../export/MarkdownExportContext'
+import todoRepository from '../repository'
 import { CreateTodoModal } from './modal'
 import { usePostHog } from 'posthog-js/react'
 
@@ -47,23 +47,9 @@ export function useCreateTodoModal(): [
 						title: todo.title,
 					})
 					if (location === ListType.asteroidField) {
-						const asteroidFieldOrder = await db.asteroidFieldOrder
-							.orderBy('order')
-							.keys()
-
-						await db.asteroidFieldOrder.add({
-							todoId: createdTodoId,
-							order: order(undefined, asteroidFieldOrder[0]?.toString()),
-						})
+						await todoRepository.addToTopOfAsteroidField(createdTodoId.toString())
 					} else if (location === ListType.wayfinder) {
-						const wayfinderOrder = await db.wayfinderOrder
-							.orderBy('order')
-							.keys()
-
-						await db.wayfinderOrder.add({
-							todoId: createdTodoId,
-							order: order(undefined, wayfinderOrder[0]?.toString()),
-						})
+						await todoRepository.addToTopOfWayfinder(createdTodoId.toString())
 					}
 				},
 			)

--- a/components/todos/edit/useEditTodoModal.ts
+++ b/components/todos/edit/useEditTodoModal.ts
@@ -3,7 +3,7 @@ import { useCallback, useRef } from 'react'
 import { ListType, Todo, db } from '../../db'
 import { useMarkdownExportContext } from '../../export/MarkdownExportContext'
 import { EditTodoModal } from './modal'
-import order from '../../common/order'
+import todoRepository from '../repository'
 import { usePostHog } from 'posthog-js/react'
 
 export function useEditTodoModal(): [
@@ -39,23 +39,13 @@ export function useEditTodoModal(): [
 					title: updatedTodo.title,
 				})
 				if (location === ListType.asteroidField) {
-					const asteroidFieldOrder = await db.asteroidFieldOrder
-						.orderBy('order')
-						.keys()
 					await Promise.all([
-						db.asteroidFieldOrder.put({
-							todoId: updatedTodo.id,
-							order: order(undefined, asteroidFieldOrder[0]?.toString()),
-						}),
+						todoRepository.addToTopOfAsteroidField(updatedTodo.id),
 						db.wayfinderOrder.where({ todoId: updatedTodo.id }).delete(),
 					])
 				} else if (location === ListType.wayfinder) {
-					const wayfinderOrder = await db.wayfinderOrder.orderBy('order').keys()
 					await Promise.all([
-						db.wayfinderOrder.put({
-							todoId: updatedTodo.id,
-							order: order(undefined, wayfinderOrder[0]?.toString()),
-						}),
+						todoRepository.addToTopOfWayfinder(updatedTodo.id),
 						db.asteroidFieldOrder.where({ todoId: updatedTodo.id }).delete(),
 					])
 				} else if (location === ListType.database) {

--- a/components/todos/repository.ts
+++ b/components/todos/repository.ts
@@ -1,9 +1,48 @@
-import { PromiseExtended } from 'dexie'
-import order from '../common/order'
+import order, { starMudder } from '../common/order'
 import { db, DexieStarfocus, Todo } from '../db'
 
 export class TodoRepository {
 	constructor(private readonly db: DexieStarfocus) {}
+
+	async addToTopOfAsteroidField(todoId: string): Promise<void> {
+		const firstItem = await db.asteroidFieldOrder.orderBy('order').first()
+		const newOrder = order(undefined, firstItem?.order)
+		await db.asteroidFieldOrder.put({ todoId, order: newOrder })
+		if (newOrder.length > 1) {
+			await this.rebalanceAsteroidFieldOrder()
+		}
+	}
+
+	async addToTopOfWayfinder(todoId: string): Promise<void> {
+		const firstItem = await db.wayfinderOrder.orderBy('order').first()
+		const newOrder = order(undefined, firstItem?.order)
+		await db.wayfinderOrder.put({ todoId, order: newOrder })
+		if (newOrder.length > 1) {
+			await this.rebalanceWayfinderOrder()
+		}
+	}
+
+	private async rebalanceAsteroidFieldOrder(): Promise<void> {
+		const items = await db.asteroidFieldOrder.orderBy('order').toArray()
+		if (items.length === 0) return
+		const newOrderKeys = starMudder(items.length)
+		await Promise.all(
+			items.map((item, index) =>
+				db.asteroidFieldOrder.update(item.todoId, { order: newOrderKeys[index] }),
+			),
+		)
+	}
+
+	private async rebalanceWayfinderOrder(): Promise<void> {
+		const items = await db.wayfinderOrder.orderBy('order').toArray()
+		if (items.length === 0) return
+		const newOrderKeys = starMudder(items.length)
+		await Promise.all(
+			items.map((item, index) =>
+				db.wayfinderOrder.update(item.todoId, { order: newOrderKeys[index] }),
+			),
+		)
+	}
 
 	async complete(todo: Todo): Promise<void> {
 		await db.transaction(
@@ -30,37 +69,13 @@ export class TodoRepository {
 			db.asteroidFieldOrder,
 			db.wayfinderOrder,
 			async () => {
-				const promises: PromiseExtended<number | string>[] = [
-					db.todos.update(todo.id, {
-						completedAt: undefined,
-					}),
-				]
+				await db.todos.update(todo.id, { completedAt: undefined })
 
 				if (todo.starPoints) {
-					const wayfinderOrder = await db.wayfinderOrder
-						.orderBy('order')
-						.limit(1)
-						.keys()
-					promises.push(
-						db.wayfinderOrder.put({
-							todoId: todo.id,
-							order: order(undefined, wayfinderOrder[0]?.toString()),
-						}),
-					)
+					await this.addToTopOfWayfinder(todo.id)
 				} else {
-					const asteroidFieldOrder = await db.asteroidFieldOrder
-						.orderBy('order')
-						.limit(1)
-						.keys()
-					promises.push(
-						db.asteroidFieldOrder.put({
-							todoId: todo.id,
-							order: order(undefined, asteroidFieldOrder[0]?.toString()),
-						}),
-					)
+					await this.addToTopOfAsteroidField(todo.id)
 				}
-
-				await Promise.all(promises)
 			},
 		)
 	}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,7 @@
   ],
   "exclude": [
     "node_modules",
-    "scripts"
+    "scripts",
+    "agent/scripts"
   ]
 }


### PR DESCRIPTION
Todos were always inserted at the top of lists using mudder's alphabet, causing order strings to grow indefinitely (e.g. 'aaaaaaaaa...') as mudder ran out of single-character space.

Added addToTopOfAsteroidField/addToTopOfWayfinder methods to automatically rebalance all order strings using evenly distributed mudder keys whenever the newly generated order string exceeds one character.

Also excludes agent/scripts from tsconfig so Bun scripts with top-level await don't break typecheck.