### PR TITLE
🧪 Add Cypress component tests and push E2E tests down

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
       - run: bun lint
       - run: bun unit
       - run: bun run build
+      - uses: cypress-io/github-action@v6
+        with:
+          install: false
+          component: true
       - run: bun start &
       - uses: cypress-io/github-action@v6
         with:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-bun typecheck && bun lint && bun unit
+bun typecheck && bun lint && bun unit && bun component

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,4 +10,11 @@ export default defineConfig({
 			// implement node event listeners here
 		},
 	},
+	component: {
+		devServer: {
+			framework: 'next',
+			bundler: 'webpack',
+		},
+		includeShadowDom: true,
+	},
 })

--- a/cypress/component/Placeholder.cy.tsx
+++ b/cypress/component/Placeholder.cy.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import Placeholder from '../../components/common/Placeholder'
+
+describe('Placeholder', () => {
+	it('renders the heading', () => {
+		cy.mount(<Placeholder heading="No todos yet" />)
+		cy.contains('h2', 'No todos yet').should('be.visible')
+	})
+
+	it('renders children', () => {
+		cy.mount(
+			<Placeholder heading="Empty">Add some todos to get started</Placeholder>,
+		)
+		cy.contains('p', 'Add some todos to get started').should('be.visible')
+	})
+
+	it('applies text-center layout', () => {
+		cy.mount(<Placeholder heading="Test" />)
+		cy.get('div').should('have.class', 'text-center')
+	})
+})

--- a/cypress/component/SearchSuggestions.cy.tsx
+++ b/cypress/component/SearchSuggestions.cy.tsx
@@ -1,0 +1,116 @@
+/**
+ * Component tests for SearchSuggestions keyboard navigation and click handling.
+ * The E2E suite (home/search.cy.ts) covers integration with the Search modal
+ * (breakpoint changes, query persistence). Tests here cover the component's own
+ * behaviour in isolation: which callbacks fire, ArrowDown/ArrowUp/Enter handling,
+ * and focus management within the list.
+ */
+import React from 'react'
+import { IonApp } from '@ionic/react'
+import { SearchSuggestions } from '../../components/search/SearchSuggestions'
+
+const SUGGESTION_COUNT = 6
+const FIRST_SUGGESTION_VALUE = 'is:snoozed'
+const LAST_SUGGESTION_INDEX = SUGGESTION_COUNT - 1
+
+function mount({
+	onClick = cy.stub(),
+	onFocusChange = cy.stub(),
+	focusedIndex = -1,
+}: {
+	onClick?: Cypress.Agent<sinon.SinonStub>
+	onFocusChange?: Cypress.Agent<sinon.SinonStub>
+	focusedIndex?: number
+} = {}) {
+	cy.mount(
+		<IonApp>
+			<SearchSuggestions
+				onClick={onClick}
+				onFocusChange={onFocusChange}
+				focusedIndex={focusedIndex}
+			/>
+		</IonApp>,
+	)
+}
+
+const suggestions = () => cy.get('ion-list ion-item')
+
+describe('SearchSuggestions', () => {
+	describe('rendering', () => {
+		it(`renders ${SUGGESTION_COUNT} suggestions`, () => {
+			mount()
+			suggestions().should('have.length', SUGGESTION_COUNT)
+		})
+
+		it('renders is:snoozed as the first suggestion', () => {
+			mount()
+			suggestions().first().should('contain.text', 'is:snoozed')
+		})
+	})
+
+	describe('click', () => {
+		it('calls onClick with the suggestion value when clicked', () => {
+			const onClick = cy.stub().as('onClick')
+			mount({ onClick })
+			suggestions().first().click()
+			cy.get('@onClick').should('have.been.calledOnceWith', FIRST_SUGGESTION_VALUE)
+		})
+	})
+
+	describe('keyboard navigation', () => {
+		it('calls onClick with the suggestion value when Enter is pressed', () => {
+			const onClick = cy.stub().as('onClick')
+			mount({ onClick, focusedIndex: 0 })
+			suggestions()
+				.first()
+				.trigger('keydown', { key: 'Enter', bubbles: true })
+			cy.get('@onClick').should('have.been.calledOnceWith', FIRST_SUGGESTION_VALUE)
+		})
+
+		it('calls onFocusChange with the next index when ArrowDown is pressed', () => {
+			const onFocusChange = cy.stub().as('onFocusChange')
+			mount({ onFocusChange, focusedIndex: 0 })
+			suggestions()
+				.first()
+				.trigger('keydown', { key: 'ArrowDown', bubbles: true })
+			cy.get('@onFocusChange').should('have.been.calledOnceWith', 1)
+		})
+
+		it('does not advance past the last suggestion on ArrowDown', () => {
+			const onFocusChange = cy.stub().as('onFocusChange')
+			mount({ onFocusChange, focusedIndex: LAST_SUGGESTION_INDEX })
+			suggestions()
+				.last()
+				.trigger('keydown', { key: 'ArrowDown', bubbles: true })
+			cy.get('@onFocusChange').should(
+				'have.been.calledOnceWith',
+				LAST_SUGGESTION_INDEX,
+			)
+		})
+
+		it('calls onFocusChange(-1) when ArrowUp is pressed on the first suggestion', () => {
+			const onFocusChange = cy.stub().as('onFocusChange')
+			mount({ onFocusChange, focusedIndex: 0 })
+			suggestions()
+				.first()
+				.trigger('keydown', { key: 'ArrowUp', bubbles: true })
+			cy.get('@onFocusChange').should('have.been.calledOnceWith', -1)
+		})
+
+		it('navigates from second to first suggestion on ArrowUp', () => {
+			const onFocusChange = cy.stub().as('onFocusChange')
+			mount({ onFocusChange, focusedIndex: 1 })
+			suggestions()
+				.eq(1)
+				.trigger('keydown', { key: 'ArrowUp', bubbles: true })
+			cy.get('@onFocusChange').should('have.been.calledOnceWith', 0)
+		})
+	})
+
+	describe('focus management', () => {
+		it('focuses the element when focusedIndex prop points to it', () => {
+			mount({ focusedIndex: 0 })
+			suggestions().first().should('be.focused')
+		})
+	})
+})

--- a/cypress/component/StarRoleIcon.cy.tsx
+++ b/cypress/component/StarRoleIcon.cy.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { IonApp } from '@ionic/react'
+import { StarRoleIcon } from '../../components/common/StarRoleIcon'
+import { StarRole } from '../../components/db'
+
+const fatherRole: StarRole = {
+	id: '1',
+	title: 'Father',
+	icon: { type: 'ionicon', name: 'maleSharp' },
+}
+
+describe('StarRoleIcon', () => {
+	it('renders with light color when no star role is provided', () => {
+		cy.mount(
+			<IonApp>
+				<StarRoleIcon />
+			</IonApp>,
+		)
+		cy.get('[data-class="star-role-icon"]').should('have.attr', 'color', 'light')
+	})
+
+	it('renders with dark color when a star role is provided', () => {
+		cy.mount(
+			<IonApp>
+				<StarRoleIcon starRole={fatherRole} />
+			</IonApp>,
+		)
+		cy.get('[data-class="star-role-icon"]').should('have.attr', 'color', 'dark')
+	})
+
+	it('sets data-star-role to the role title', () => {
+		cy.mount(
+			<IonApp>
+				<StarRoleIcon starRole={fatherRole} />
+			</IonApp>,
+		)
+		cy.get('[data-class="star-role-icon"]').should(
+			'have.attr',
+			'data-star-role',
+			'Father',
+		)
+	})
+
+	it('does not set data-star-role when no star role is provided', () => {
+		cy.mount(
+			<IonApp>
+				<StarRoleIcon />
+			</IonApp>,
+		)
+		cy.get('[data-class="star-role-icon"]').should(
+			'not.have.attr',
+			'data-star-role',
+		)
+	})
+})

--- a/cypress/e2e/home/search.cy.ts
+++ b/cypress/e2e/home/search.cy.ts
@@ -76,25 +76,9 @@ describe('open', () => {
 		cy.focused().should('have.prop', 'tagName', 'ION-ITEM')
 	})
 
-	it('returns focus to searchbar on ArrowUp from first suggestion', () => {
-		pressKey('ArrowDown')
-		suggestions().first().trigger('keydown', { key: 'ArrowUp', bubbles: true })
-		searchInput().should('be.focused')
-	})
-
-	it('navigates down through multiple suggestions', () => {
-		pressKey('ArrowDown')
-		suggestions()
-			.first()
-			.trigger('keydown', { key: 'ArrowDown', bubbles: true })
-		suggestions()
-			.eq(1)
-			.then($second => {
-				cy.focused().should($focused => {
-					expect($focused[0]).to.equal($second[0])
-				})
-			})
-	})
+	// ArrowUp / ArrowDown within the suggestion list and stopping at boundaries are
+	// covered by cypress/component/SearchSuggestions.cy.tsx. The tests below cover
+	// only the integration concerns: modal breakpoint changes and query persistence.
 
 	it('selects a suggestion on Enter, keeps the query and snaps to peek', () => {
 		pressKey('ArrowDown')
@@ -111,31 +95,6 @@ describe('open', () => {
 		cy.wait(ANIMATION_MS)
 		shouldHaveBreakpoint(PEEK_BREAKPOINT)
 		searchModal().should('have.attr', 'data-query', 'is:snoozed')
-	})
-
-	it('stops at the last suggestion', () => {
-		pressKey('ArrowDown')
-		suggestions().each((_, index, list) => {
-			if (index < list.length - 1) {
-				cy.wrap(list[index]).trigger('keydown', {
-					key: 'ArrowDown',
-					bubbles: true,
-					force: true,
-				})
-			}
-		})
-		// One more ArrowDown on the last item — should stay on last
-		suggestions()
-			.last()
-			.trigger('keydown', { key: 'ArrowDown', bubbles: true, force: true })
-		suggestions()
-			.last()
-			.then($last => {
-				// Use .should() so Cypress retries until React settles after rapid triggers
-				cy.focused().should($focused => {
-					expect($focused[0]).to.equal($last[0])
-				})
-			})
 	})
 
 	it('opens to 100% when the suggestions are focused', () => {

--- a/cypress/support/component-index.html
+++ b/cypress/support/component-index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>Components App</title>
+  </head>
+  <body>
+    <div data-cy-root></div>
+  </body>
+</html>

--- a/cypress/support/component.ts
+++ b/cypress/support/component.ts
@@ -1,0 +1,24 @@
+import { mount } from 'cypress/react'
+import { setupIonicReact } from '@ionic/react'
+
+// CSS imports are omitted here: Next.js's style-loader runs at module-evaluation
+// time and crashes when document.head is not yet available in the Cypress iframe.
+// Component tests check behaviour (callbacks, data-attributes), not visual style.
+setupIonicReact({})
+
+Cypress.Commands.add('mount', mount)
+
+Cypress.on('uncaught:exception', err => {
+	if (err.message.includes('ResizeObserver loop')) {
+		return false
+	}
+})
+
+declare global {
+	// eslint-disable-next-line @typescript-eslint/no-namespace
+	namespace Cypress {
+		interface Chainable {
+			mount: typeof mount
+		}
+	}
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -23,8 +23,9 @@
 		"lint": "eslint .",
 		"format": "prettier --write components/ interfaces/ pages/ public/ styles/ utils/",
 		"unit": "bun test",
+		"component": "cypress run --component",
 		"integration": "cypress run",
-		"test": "bun typecheck && bun lint && bun unit && bun integration",
+		"test": "bun typecheck && bun lint && bun unit && bun component && bun integration",
 		"build": "next build --webpack",
 		"start": "serve -p 6603 out"
 	},


### PR DESCRIPTION
- Configure cypress.config.ts with component devServer (Next.js + webpack)
- Add cypress/support/component.ts (Ionic setup, mount command)
- Add cypress/support/component-index.html (required HTML template)
- Add component tests for Placeholder, StarRoleIcon, SearchSuggestions
- Remove in-suggestions keyboard nav tests from E2E search.cy.ts (now in
  SearchSuggestions component test: ArrowDown/ArrowUp, boundary, Enter, click)
- Add 'component' script to package.json; include in 'test' script
- Run component tests on pre-commit (.husky/pre-commit)
- Run component tests in CI before E2E (cypress-io/github-action component: true)

https://claude.ai/code/session_01HuRvaEpbrAJftvPfXgQP6K